### PR TITLE
remove vagrant code

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,9 +8,10 @@
 httpd_dn_suffix: 'example.com'
 ## Your email address
 email: 'user@example.com'
-## Let's encrypt cert paths
-#httpd_cert_path: '/vagrant/letsencrypt/etc/live/'
-#httpd_key_path: '/vagrant/letsencrypt/etc/live/'
+## Let's encrypt paths
+#letsencrypt_path: '/opt/letsencrypt'
+#httpd_cert_path: "{{ letsencrypt_path }}/etc/live/"
+#httpd_key_path: "{{ letsencrypt_path }}/etc/live/"
 ## Self-signed cert paths
 httpd_cert_path: '/etc/pki/tls/certs/'
 httpd_key_path: '/etc/pki/tls/private/'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -20,8 +20,6 @@
     group: root
 - name: Comment out the welcome conf
   command: sed -i "s/^[^#]/#&/" /etc/httpd/conf.d/welcome.conf
-- name: Add vagrant user to apache group
-  command: usermod -a -G apache vagrant
 - name: Set permissions for /srv
   file: path=/srv owner=apache group=apache mode=0775
 - name: Run Apache httpd on boot

--- a/tasks/ssl-letsencrypt.yml
+++ b/tasks/ssl-letsencrypt.yml
@@ -1,18 +1,16 @@
 ---
 - name: Git letsencrypt.
-  sudo_user: vagrant
   git: repo=https://github.com/letsencrypt/letsencrypt
-       dest=/vagrant/letsencrypt/build force=yes
+       dest="{{ letsencrypt_path }}"/build force=yes
 - name: Ensure Apache is stopped
   service:
     name: httpd
     state: stopped
 - name: Generate key and CSR, and get a signed cert.
-  sudo: yes
   command: >
-    stat /vagrant/letsencrypt/etc/live/"{{ item }}"."{{ httpd_dn_suffix }}" || ./letsencrypt-auto certonly --renew-by-default --text --config-dir /vagrant/letsencrypt/etc --standalone --standalone-supported-challenges http-01 --email "{{ email }}" --agree-tos -d "{{ item }}"."{{ httpd_dn_suffix }}"
+    stat "{{ letsencrypt_path }}"/etc/live/"{{ item }}"."{{ httpd_dn_suffix }}" || ./letsencrypt-auto certonly --renew-by-default --text --config-dir "{{ letsencrypt_path }}"/etc --standalone --standalone-supported-challenges http-01 --email "{{ email }}" --agree-tos -d "{{ item }}"."{{ httpd_dn_suffix }}"
   args:
-    chdir: /vagrant/letsencrypt/build
+    chdir: "{{ letsencrypt_path }}"/build
   with_items: sites
 - name: Ensure Apache is started
   service:


### PR DESCRIPTION
Remove all vagrant references and replace with more generic code where applicable.
## Motivation and Context

We don't want vagrant garbage on non-vagrant systems. See issue:
https://github.com/OULibraries/ansible-role-apache2/issues/1
## How Has This Been Tested?

vagrant up
d7_\* scripts
