### PR TITLE
Create virtual a default virtual host for sni

### DIFF
--- a/files/00srv_default.conf
+++ b/files/00srv_default.conf
@@ -1,0 +1,20 @@
+<VirtualHost *:443>
+
+  Include /etc/httpd/conf.d/00ssl.include
+  SSLCertificateFile ${HTTPD_CERT_PATH}/star.${HTTPD_DN_SUFFIX}/cert.pem
+  SSLCertificateKeyFile ${HTTPD_KEY_PATH}/star.${HTTPD_DN_SUFFIX}/privkey.pem
+  SSLCertificateChainFile ${HTTPD_CERT_PATH}/star.${HTTPD_DN_SUFFIX}/chain.pem
+
+  ServerName default.${HTTPD_DN_SUFFIX}
+  DocumentRoot /dev/null
+  Redirect 404 /
+
+  <Directory "/srv/libraries/drupal">
+    Options Indexes FollowSymLinks
+    AllowOverride All
+    Order allow,deny
+    Allow from all
+    Require all granted
+  </Directory>
+
+</VirtualHost>

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -17,6 +17,13 @@
     mode: 0644
     owner: root
     group: root
+- name: 00srv_default.conf
+  copy:
+    src: 00srv_default.conf
+    dest: /etc/httpd/conf.d/00srv_default.conf
+    mode: 0644
+    owner: root
+    group: root
 - name: Comment out the welcome conf
   command: sed -i "s/^[^#]/#&/" /etc/httpd/conf.d/welcome.conf
 - name: Set permissions for /srv


### PR DESCRIPTION
## Motivation and Context

When somebody requests a host without a site, but is valid due to our wilcard dns and ssl, they get a random website.  they should get at least an error page
## How Has This Been Tested?

I dropped this config file in a devel environment and it seemed okay. needs more testing.
